### PR TITLE
Add: get expense types id and names without auth

### DIFF
--- a/packages/api/src/controllers/farmExpenseTypeController.js
+++ b/packages/api/src/controllers/farmExpenseTypeController.js
@@ -61,7 +61,7 @@ const farmExpenseTypeController = {
         res.status(200).send(result);
       } catch (error) {
         res.status(400).json({
-          error,
+          error: error.message || 'An unexpected error occurred',
         });
       }
     };

--- a/packages/api/src/controllers/farmExpenseTypeController.js
+++ b/packages/api/src/controllers/farmExpenseTypeController.js
@@ -54,6 +54,19 @@ const farmExpenseTypeController = {
     };
   },
 
+  getAllFarmExpenseTypeAndNames() {
+    return async (_, res) => {
+      try {
+        const result = await ExpenseTypeModel.query().select('expense_type_id', 'expense_name');
+        res.status(200).send(result);
+      } catch (error) {
+        res.status(400).json({
+          error,
+        });
+      }
+    };
+  },
+
   getFarmExpenseType() {
     return async (req, res) => {
       try {

--- a/packages/api/src/middleware/acl/checkJwt.js
+++ b/packages/api/src/middleware/acl/checkJwt.js
@@ -26,6 +26,7 @@ const checkJwt = expressjwt({
     '/user/accept_invitation',
     '/user_farm/accept_invitation',
     '/notification_user/subscribe',
+    '/expense_type/all',
     /\/time_notification\//i,
     /\/farm\/utc_offset_by_range\//i,
     /\/sensor\/reading\/partner\/\d+\/farm\/*/,

--- a/packages/api/src/routes/farmExpenseTypeRoute.js
+++ b/packages/api/src/routes/farmExpenseTypeRoute.js
@@ -26,6 +26,10 @@ router.post(
   checkScope(['add:expense_types']),
   farmExpenseTypeController.addFarmExpenseType(),
 );
+router.get(
+  '/all',
+  farmExpenseTypeController.getAllFarmExpenseTypeAndNames(),
+);
 
 router.get(
   '/farm/:farm_id',


### PR DESCRIPTION
**Description**

This pull request introduces a new API endpoint to fetch all farm expense types and their names, along with necessary updates to the middleware and routing to support this functionality.

### New API Endpoint for Fetching Expense Types:
* **`farmExpenseTypeController.js`**: Added a new method `getAllFarmExpenseTypeAndNames` to fetch `expense_type_id` and `expense_name` from the `ExpenseTypeModel`. It handles errors by returning a 400 status with an error message.

### Middleware Update:
* **`checkJwt.js`**: Added the new `/expense_type/all` route to the list of paths excluded from JWT authentication. This allows unauthenticated access to the new endpoint.

### Route Addition:
* **`farmExpenseTypeRoute.js`**: Registered a new `GET /expense_type/all` route that uses the `getAllFarmExpenseTypeAndNames` method from the controller.
