### PR TITLE
Add documentation comments for revenue type and user farm routes

### DIFF
--- a/packages/api/src/controllers/revenueTypeController.js
+++ b/packages/api/src/controllers/revenueTypeController.js
@@ -61,6 +61,7 @@ const revenueTypeController = {
     };
   },
 
+  // Get all revenue types
   getFarmRevenueType() {
     return async (req, res) => {
       try {

--- a/packages/api/src/controllers/userFarmController.js
+++ b/packages/api/src/controllers/userFarmController.js
@@ -31,6 +31,7 @@ const validStatusChanges = {
 };
 
 const userFarmController = {
+  // Get all farms for a user
   getUserFarmByUserID() {
     return async (req, res) => {
       try {

--- a/packages/api/src/routes/revenueTypeRoute.js
+++ b/packages/api/src/routes/revenueTypeRoute.js
@@ -26,12 +26,18 @@ router.post(
   checkScope(['add:revenue_types']),
   RevenueTypeController.addType(),
 );
+
+// Route to get all revenue types for a specific farm
+// Before this route is executed, the user must have access to the farm
+// and the scope 'get:revenue_types' must be checked
 router.get(
   '/farm/:farm_id',
   hasFarmAccess({ params: 'farm_id' }),
   checkScope(['get:revenue_types']),
   RevenueTypeController.getFarmRevenueType(),
 );
+//
+
 router.get(
   '/:revenue_type_id',
   hasFarmAccess({ params: 'revenue_type_id' }),

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -307,7 +307,10 @@ app
   .use('/crop_variety', cropVarietyRoutes)
   .use('/field', fieldRoutes)
   .use('/sale', saleRoutes)
+
+  // Route registration to retrieve user farm  revenue type
   .use('/revenue_type', revenueTypeRoute)
+
   .use('/task_type', taskTypeRoutes)
   .use('/soil_amendment_purposes', soilAmendmentPurposeRoute)
   .use('/soil_amendment_methods', soilAmendmentMethodRoute)
@@ -326,7 +329,10 @@ app
   .use('/price', priceRoutes)
   .use('/insight', insightRoutes)
   .use('/farmdata', userFarmDataRoute)
+
+  // Route registration to retrieve user farm data
   .use('/user_farm', userFarmRoute)
+
   .use('/roles', rolesRoutes)
   .use('/organic_certifier_survey', organicCertifierSurveyRoutes)
   .use('/support_ticket', supportTicketRoute)


### PR DESCRIPTION
Enhance code clarity by adding documentation comments for the revenue type and user farm routes, improving maintainability and understanding of the codebase.