### PR TITLE
Add routes for retrieving crop varieties by farm ID

### DIFF
--- a/packages/api/src/routes/cropVarietyRoute.js
+++ b/packages/api/src/routes/cropVarietyRoute.js
@@ -30,12 +30,16 @@ router.get(
   checkScope(['get:crop_variety']),
   cropVarietyController.getCropVarietyByCropVarietyId(),
 );
+
+// Route to get all crop varieties by farm id
+// Farm id must be passed in the request params and the user must have access to the farm
 router.get(
   '/farm/:farm_id',
   hasFarmAccess({ params: 'farm_id' }),
   checkScope(['get:crop_variety']),
   cropVarietyController.getCropVarietiesByFarmId(),
 );
+
 router.post(
   '/',
   hasFarmAccess({ body: 'farm_id' }),

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -304,7 +304,10 @@ app
   .use('/location', locationRoute)
   .use('/userLog', userLogRoute)
   .use('/crop', cropRoutes)
+
+  // Route for crop varieties logic
   .use('/crop_variety', cropVarietyRoutes)
+
   .use('/field', fieldRoutes)
   .use('/sale', saleRoutes)
   .use('/revenue_type', revenueTypeRoute)


### PR DESCRIPTION
Introduce a new route to fetch all crop varieties associated with a specific farm ID, ensuring that users have the necessary access rights.